### PR TITLE
Change skill proposal controller logic to not check "Do not award" responses for skill level availability

### DIFF
--- a/app/Http/Controllers/Training/Skills/ProposalController.php
+++ b/app/Http/Controllers/Training/Skills/ProposalController.php
@@ -181,7 +181,8 @@ class ProposalController extends Controller
             $skill = Skill::find($proposal->skill_id);
 
             // Check the level awarded is available
-            if (!$skill->isLevelAvailable($request->get('awarded_level'))) {
+            if ($request->get('awarded_level') > 0 &&
+			!$skill->isLevelAvailable($request->get('awarded_level'))) {
                 $validator->errors()->add('awarded_level', 'Please select a level that\'s available');
             }
         }));

--- a/resources/views/app/includes/footer_details.blade.php
+++ b/resources/views/app/includes/footer_details.blade.php
@@ -39,6 +39,7 @@
             <li><a href="{{ route('contact.book.terms') }}">Terms and Conditions</a></li>
             <li><a href="{{ route('page.show', ['slug' => 'faq']) }}">Frequently Asked Questions</a></li>
             <li><a href="{{ route('page.show', ['slug' => 'links']) }}">Useful Links</a></li>
+            <li><a href="{{ route('page.show', ['slug' => 'privacy-policy']) }}">Privacy Policy</a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
Proposed solution is to amend the controller to only check whether the assigned skill level is allowed if the assigned skill level is greater than 0 (i.e. not "Do not award").

Proposes to close issue #54 